### PR TITLE
Add GCS Database Project to portfolio projects

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,48 +1,14 @@
-import { Button } from "@/components/ui/button"
 import { PageBackground } from "@/components/ui/page-background"
-import { Construction } from "lucide-react"
-import Link from "next/link"
-import { type Project } from '@/lib/projectData'
 import { SpotlightContainer } from '@/components/ui/spotlight-container'
 import { ProjectCardAdvanced } from '@/components/ui/project-card-advanced'
+import { getProjects } from '@/lib/projectData'
 
-// Mark as static page
 export const dynamic = 'force-static'
 export const revalidate = false
 
-const projects: Project[] = [
-  {
-    id: "data-integration",
-    title: "Data Integration Platform",
-    description: "Led a 5-person Scrum team using Jira for sprint planning and backlog grooming, achieving 95% sprint velocity and delivering features on time across 6 sprints. Architected microservices using Spring Boot and domain-driven design.",
-    tags: ["Java", "Spring Boot", "RESTful APIs", "Git/GitHub", "Jenkins", "Oracle SQL"],
-    imageUrl: "/placeholder.jpg",
-    projectUrl: "/projects",
-    featured: true,
-    date: "March 2024"
-  },
-  {
-    id: "enterprise-platform",
-    title: "Enterprise Data Integration Platform",
-    description: "Architected backend services using distributed systems principles, implementing fault-tolerant network protocols with 95% test coverage. Designed microservices architecture using Apache Kafka and AWS SQS, ensuring 99.9% message delivery reliability.",
-    tags: ["Python", "Java", "AWS", "Apache Kafka", "React", "Microservices"],
-    imageUrl: "/placeholder.jpg",
-    projectUrl: "/projects",
-    featured: true,
-    date: "January 2024"
-  },
-  {
-    id: "cloud-migration",
-    title: "Cloud Migration Project",
-    description: "Led the migration of on-premises infrastructure to AWS cloud, implementing Infrastructure as Code using Terraform and CloudFormation. Reduced operational costs by 40% and improved system reliability.",
-    tags: ["AWS", "Terraform", "Docker", "Python", "CI/CD"],
-    imageUrl: "/placeholder.jpg",
-    projectUrl: "/projects",
-    date: "October 2023"
-  }
-];
-
 export default function ProjectsPage() {
+  const projects = getProjects()
+
   return (
     <PageBackground variant="dark">
       <div className="flex flex-col items-center justify-center min-h-screen py-16 px-4">

--- a/lib/projectData.ts
+++ b/lib/projectData.ts
@@ -12,6 +12,16 @@ export interface Project {
 export function getProjects(): Project[] {
   return [
     {
+      id: "cs-database-project",
+      title: "Global Computer Solutions (GCS) Database Project",
+      description: "Fully normalized SQL Server database for a consulting firm: employees, skills, projects, tasks, time tracking, and billing; designed to 3NF with referential integrity and reporting.",
+      tags: ["SQL Server", "Database Design", "3NF", "ERD", "Reporting"],
+      imageUrl: "https://opengraph.githubassets.com/1/tdalal17/cs-database-project",
+      projectUrl: "https://github.com/tdalal17/cs-database-project",
+      featured: true,
+      date: "Aug 2025"
+    },
+    {
       id: "data-integration",
       title: "Data Integration Platform",
       description: "Led a 5-person Scrum team using Jira for sprint planning and backlog grooming, achieving 95% sprint velocity and delivering features on time across 6 sprints. Architected microservices using Spring Boot and domain-driven design.",


### PR DESCRIPTION
Add the "Global Computer Solutions (GCS) Database Project" to the portfolio. Source: https://github.com/tdalal17/cs-database-project

- Adds a new project entry in lib/projectData.ts using GitHub OG image and repo URL
- Refactors app/projects/page.tsx to read from lib/projectData.ts so projects are single-source

This exposes your database design work (3NF schema, reporting, ERD) prominently.

Next: share the second repo link to add it similarly.