### PR TITLE
Simple case study system + link GCS project to /projects/[id]

### DIFF
--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -1,0 +1,37 @@
+import { PageBackground } from "@/components/ui/page-background"
+import { SpotlightContainer } from "@/components/ui/spotlight-container"
+import Link from "next/link"
+import { simpleCaseStudies } from "@/lib/caseStudies"
+
+export const dynamic = "force-static"
+export const revalidate = false
+
+export async function generateStaticParams() {
+  return Object.keys(simpleCaseStudies).map((id) => ({ id }))
+}
+
+export default function CaseStudyPage({ params }: { params: { id: string } }) {
+  const cs = simpleCaseStudies[params.id]
+  if (!cs) return <div className="container py-16">Not found</div>
+
+  return (
+    <PageBackground variant="dark">
+      <div className="container px-4 py-12 md:px-6 md:py-16">
+        <SpotlightContainer className="p-8 space-y-6">
+          <h1 className="text-3xl md:text-4xl font-bold">{cs.title}</h1>
+          <p className="text-muted-foreground md:text-lg">{cs.summary}</p>
+          <div className="space-y-4 text-muted-foreground">
+            {cs.body.map((p, i) => (
+              <p key={i}>{p}</p>
+            ))}
+          </div>
+          {cs.repoUrl && (
+            <div className="pt-2">
+              <Link href={cs.repoUrl} target="_blank" className="underline">View on GitHub</Link>
+            </div>
+          )}
+        </SpotlightContainer>
+      </div>
+    </PageBackground>
+  )
+}

--- a/lib/caseStudies/index.ts
+++ b/lib/caseStudies/index.ts
@@ -1,0 +1,21 @@
+export interface SimpleCaseStudy {
+  id: string
+  title: string
+  summary: string
+  body: string[]
+  repoUrl?: string
+}
+
+export const simpleCaseStudies: Record<string, SimpleCaseStudy> = {
+  "cs-database-project": {
+    id: "cs-database-project",
+    title: "Global Computer Solutions (GCS) Database Project",
+    summary: "Fully normalized SQL Server database for consulting ops: employees, skills, projects, tasks, time & billing.",
+    body: [
+      "Implements 11 interconnected tables in 3NF with enforced referential integrity.",
+      "Tracks employee skills, assignments, work logs, billing, and project financials.",
+      "Includes BI reports for skills utilization, project financials, and progress.",
+    ],
+    repoUrl: "https://github.com/tdalal17/cs-database-project",
+  },
+}

--- a/lib/projectData.ts
+++ b/lib/projectData.ts
@@ -12,6 +12,16 @@ export interface Project {
 export function getProjects(): Project[] {
   return [
     {
+      id: "cs-database-project",
+      title: "Global Computer Solutions (GCS) Database Project",
+      description: "Fully normalized SQL Server database for a consulting firm: employees, skills, projects, tasks, time tracking, and billing; designed to 3NF with referential integrity and reporting.",
+      tags: ["SQL Server", "Database Design", "3NF", "ERD", "Reporting"],
+      imageUrl: "https://opengraph.githubassets.com/1/tdalal17/cs-database-project",
+      projectUrl: "/projects/cs-database-project",
+      featured: true,
+      date: "Aug 2025"
+    },
+    {
       id: "data-integration",
       title: "Data Integration Platform",
       description: "Led a 5-person Scrum team using Jira for sprint planning and backlog grooming, achieving 95% sprint velocity and delivering features on time across 6 sprints. Architected microservices using Spring Boot and domain-driven design.",


### PR DESCRIPTION
Add minimal case study support and link the GCS Database Project to a clean, simple details page with a GitHub link at the end.

- Adds lib/caseStudies/index.ts (id, title, summary, body[], repoUrl)
- Adds app/projects/[id]/page.tsx (renders case study by id)
- Updates cs-database-project card to point to /projects/cs-database-project

This scales to multiple projects without complexity; just add entries to simpleCaseStudies.